### PR TITLE
feat: use view actions for private callbacks over Tailscale

### DIFF
--- a/plugin/notifier.js
+++ b/plugin/notifier.js
@@ -105,24 +105,21 @@ export async function sendPermissionNotification({
     tags: ['lock'],
     actions: [
       {
-        action: 'http',
+        action: 'view',
         label: 'Allow Once',
         url: `${callbackUrl}?nonce=${nonce}&response=once`,
-        method: 'POST',
         clear: true,
       },
       {
-        action: 'http',
+        action: 'view',
         label: 'Allow Always',
         url: `${callbackUrl}?nonce=${nonce}&response=always`,
-        method: 'POST',
         clear: true,
       },
       {
-        action: 'http',
+        action: 'view',
         label: 'Reject',
         url: `${callbackUrl}?nonce=${nonce}&response=reject`,
-        method: 'POST',
         clear: true,
       },
     ],

--- a/test/test_notifier.bash
+++ b/test/test_notifier.bash
@@ -171,11 +171,11 @@ test_permission_notification_has_reject_action() {
   }
 }
 
-test_permission_notification_uses_http_action_type() {
-  # ntfy actions should be HTTP type for callbacks
-  grep -q '"http"' "$PLUGIN_DIR/notifier.js" || \
-  grep -q "'http'" "$PLUGIN_DIR/notifier.js" || {
-    echo "HTTP action type not found in notifier.js"
+test_permission_notification_uses_view_action_type() {
+  # ntfy actions should be view type for callbacks (opens in browser, request comes from phone)
+  grep -q '"view"' "$PLUGIN_DIR/notifier.js" || \
+  grep -q "'view'" "$PLUGIN_DIR/notifier.js" || {
+    echo "view action type not found in notifier.js"
     return 1
   }
 }
@@ -307,7 +307,7 @@ for test_func in \
   test_permission_notification_has_allow_once_action \
   test_permission_notification_has_allow_always_action \
   test_permission_notification_has_reject_action \
-  test_permission_notification_uses_http_action_type \
+  test_permission_notification_uses_view_action_type \
   test_permission_notification_uses_callback_url \
   test_permission_notification_includes_nonce \
   test_permission_notification_includes_response_param \


### PR DESCRIPTION
## Summary
- Change ntfy action type from `http` to `view` so permission callbacks are made directly from the phone's browser over Tailscale (fully private, no exposure to ntfy servers)
- Callback server now accepts GET requests and returns user-friendly HTML confirmation pages
- Updated tests to verify `view` action type