### PR TITLE
fix: add push-to and create-branch params for direct push

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -24,6 +24,11 @@ jobs:
           homebrew-tap: athal7/homebrew-tap
           tag-name: ${{ github.event.release.tag_name }}
           download-url: https://github.com/athal7/opencode-ntfy.git
+          push-to: athal7/homebrew-tap
+          base-branch: main
           create-pullrequest: false
+          create-branch: false
+          commit-message: |
+            chore: bump {{formulaName}} to {{version}}
         env:
           COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Add `push-to`, `base-branch`, and `create-branch: false` params
- Fixes direct push to homebrew-tap when main branch is protected
- Adds proper commit message format