### PR TITLE
fix: status reads config file and integration tests use isolated HOME

### DIFF
--- a/bin/opencode-ntfy
+++ b/bin/opencode-ntfy
@@ -100,6 +100,49 @@ cmd_setup() {
   echo "Optional: Set NTFY_CALLBACK_HOST for interactive permissions"
 }
 
+NTFY_CONFIG_FILE="$HOME/.config/opencode-ntfy/config.json"
+
+# Read a value from config file (JSON)
+read_config_value() {
+  local key="$1"
+  if [[ -f "$NTFY_CONFIG_FILE" ]]; then
+    node -e "
+      const fs = require('fs');
+      try {
+        const config = JSON.parse(fs.readFileSync('$NTFY_CONFIG_FILE', 'utf8'));
+        if (config['$key'] !== undefined && config['$key'] !== '') {
+          console.log(config['$key']);
+        }
+      } catch (e) {}
+    " 2>/dev/null
+  fi
+}
+
+# Get effective config value (env var > config file > default)
+get_config() {
+  local env_var="$1"
+  local config_key="$2"
+  local default_value="${3:-}"
+  
+  # Check env var first
+  local env_value="${!env_var:-}"
+  if [[ -n "$env_value" ]]; then
+    echo "$env_value"
+    return
+  fi
+  
+  # Check config file
+  local file_value
+  file_value=$(read_config_value "$config_key")
+  if [[ -n "$file_value" ]]; then
+    echo "$file_value"
+    return
+  fi
+  
+  # Return default
+  echo "$default_value"
+}
+
 cmd_status() {
   echo "opencode-ntfy status"
   echo "===================="
@@ -126,13 +169,39 @@ cmd_status() {
     echo "Service: not running (run: brew services start opencode-ntfy)"
   fi
   
-  # Environment
+  # Configuration (from config file and/or environment)
   echo ""
-  echo "Environment:"
-  echo "  NTFY_TOPIC: ${NTFY_TOPIC:-<not set>}"
-  echo "  NTFY_SERVER: ${NTFY_SERVER:-https://ntfy.sh (default)}"
-  echo "  NTFY_CALLBACK_HOST: ${NTFY_CALLBACK_HOST:-<not set>}"
-  echo "  NTFY_CALLBACK_PORT: ${NTFY_CALLBACK_PORT:-4097 (default)}"
+  echo "Configuration:"
+  
+  local topic server callback_host callback_port
+  topic=$(get_config "NTFY_TOPIC" "topic" "")
+  server=$(get_config "NTFY_SERVER" "server" "https://ntfy.sh")
+  callback_host=$(get_config "NTFY_CALLBACK_HOST" "callbackHost" "")
+  callback_port=$(get_config "NTFY_CALLBACK_PORT" "callbackPort" "4097")
+  
+  if [[ -n "$topic" ]]; then
+    echo "  topic: $topic"
+  else
+    echo "  topic: <not set>"
+  fi
+  
+  echo "  server: $server"
+  
+  if [[ -n "$callback_host" ]]; then
+    echo "  callbackHost: $callback_host"
+  else
+    echo "  callbackHost: <not set>"
+  fi
+  
+  echo "  callbackPort: $callback_port"
+  
+  # Show config file status
+  echo ""
+  if [[ -f "$NTFY_CONFIG_FILE" ]]; then
+    echo "Config file: $NTFY_CONFIG_FILE"
+  else
+    echo "Config file: not found ($NTFY_CONFIG_FILE)"
+  fi
 }
 
 cmd_help() {

--- a/test/test_cli.bash
+++ b/test/test_cli.bash
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+#
+# Tests for bin/opencode-ntfy CLI
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test_helper.bash"
+
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+CLI_PATH="$PROJECT_DIR/bin/opencode-ntfy"
+
+echo "Testing opencode-ntfy CLI..."
+echo ""
+
+# =============================================================================
+# File Structure Tests
+# =============================================================================
+
+test_cli_file_exists() {
+  assert_file_exists "$CLI_PATH"
+}
+
+test_cli_is_executable() {
+  [[ -x "$CLI_PATH" ]] || {
+    echo "CLI is not executable"
+    return 1
+  }
+}
+
+# =============================================================================
+# Help Command Tests
+# =============================================================================
+
+test_cli_help_shows_usage() {
+  "$CLI_PATH" help 2>&1 | grep -q "Usage:" || {
+    echo "help command should show Usage"
+    return 1
+  }
+}
+
+test_cli_help_shows_commands() {
+  "$CLI_PATH" help 2>&1 | grep -q "Commands:" || {
+    echo "help command should show Commands"
+    return 1
+  }
+}
+
+# =============================================================================
+# Status Command Tests
+# =============================================================================
+
+test_status_shows_header() {
+  local output
+  output=$("$CLI_PATH" status 2>&1)
+  echo "$output" | grep -q "opencode-ntfy status" || {
+    echo "status should show header"
+    return 1
+  }
+}
+
+test_status_shows_config_section() {
+  # Status should have a Configuration section showing config file values
+  local output
+  output=$("$CLI_PATH" status 2>&1)
+  echo "$output" | grep -q "Configuration:" || {
+    echo "status should show Configuration section"
+    return 1
+  }
+}
+
+test_status_reads_config_file() {
+  setup_test_env
+  
+  # Create a config file with test values
+  mkdir -p "$HOME/.config/opencode-ntfy"
+  cat > "$HOME/.config/opencode-ntfy/config.json" <<EOF
+{
+  "topic": "test-topic-123",
+  "callbackHost": "test-host.example.com"
+}
+EOF
+  
+  # Status should show values from config file
+  local output
+  output=$("$CLI_PATH" status 2>&1)
+  
+  cleanup_test_env
+  
+  echo "$output" | grep -q "test-topic-123" || {
+    echo "status should show topic from config file"
+    echo "Output: $output"
+    return 1
+  }
+}
+
+test_status_shows_callback_host_from_config() {
+  setup_test_env
+  
+  # Create a config file with callbackHost
+  mkdir -p "$HOME/.config/opencode-ntfy"
+  cat > "$HOME/.config/opencode-ntfy/config.json" <<EOF
+{
+  "topic": "my-topic",
+  "callbackHost": "my-tailscale-host.ts.net"
+}
+EOF
+  
+  # Status should show callbackHost from config file
+  local output
+  output=$("$CLI_PATH" status 2>&1)
+  
+  cleanup_test_env
+  
+  echo "$output" | grep -q "my-tailscale-host.ts.net" || {
+    echo "status should show callbackHost from config file"
+    echo "Output: $output"
+    return 1
+  }
+}
+
+test_status_shows_not_set_when_missing() {
+  setup_test_env
+  
+  # Create an empty config file
+  mkdir -p "$HOME/.config/opencode-ntfy"
+  echo '{}' > "$HOME/.config/opencode-ntfy/config.json"
+  
+  # Unset any env vars
+  unset NTFY_TOPIC NTFY_CALLBACK_HOST 2>/dev/null || true
+  
+  # Status should show "not set" for missing values
+  local output
+  output=$("$CLI_PATH" status 2>&1)
+  
+  cleanup_test_env
+  
+  # Should indicate topic is not configured
+  echo "$output" | grep -qi "topic.*not set\|topic.*<not" || {
+    echo "status should indicate topic is not set"
+    echo "Output: $output"
+    return 1
+  }
+}
+
+test_status_env_overrides_config() {
+  setup_test_env
+  
+  # Create a config file
+  mkdir -p "$HOME/.config/opencode-ntfy"
+  cat > "$HOME/.config/opencode-ntfy/config.json" <<EOF
+{
+  "topic": "config-topic"
+}
+EOF
+  
+  # Set env var to override
+  export NTFY_TOPIC="env-topic"
+  
+  local output
+  output=$("$CLI_PATH" status 2>&1)
+  
+  unset NTFY_TOPIC
+  cleanup_test_env
+  
+  # Should show env var value, not config file value
+  echo "$output" | grep -q "env-topic" || {
+    echo "status should show env var value when set"
+    echo "Output: $output"
+    return 1
+  }
+}
+
+# =============================================================================
+# Run Tests
+# =============================================================================
+
+echo "File Structure Tests:"
+
+for test_func in \
+  test_cli_file_exists \
+  test_cli_is_executable
+do
+  run_test "${test_func#test_}" "$test_func"
+done
+
+echo ""
+echo "Help Command Tests:"
+
+for test_func in \
+  test_cli_help_shows_usage \
+  test_cli_help_shows_commands
+do
+  run_test "${test_func#test_}" "$test_func"
+done
+
+echo ""
+echo "Status Command Tests:"
+
+for test_func in \
+  test_status_shows_header \
+  test_status_shows_config_section \
+  test_status_reads_config_file \
+  test_status_shows_callback_host_from_config \
+  test_status_shows_not_set_when_missing \
+  test_status_env_overrides_config
+do
+  run_test "${test_func#test_}" "$test_func"
+done
+
+print_summary


### PR DESCRIPTION
## Summary
- Status command now reads from `~/.config/opencode-ntfy/config.json` in addition to environment variables
- Added `get_config()` helper with priority: env var > config file > default
- Changed "Environment" section to "Configuration" in status output
- Integration tests now use temp HOME directory with symlinked config
- Prevents test suite from polluting user's OpenCode session list
- Added `test/test_cli.bash` with tests for status command behavior