### PR TITLE
fix: use npm install instead of npm ci (no package-lock.json)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           node-version: '20'
 
       - name: Install Node.js dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run semantic-release
         id: semantic


### PR DESCRIPTION
- Change `npm ci` to `npm install` since there's no package-lock.json in the repo