### PR TITLE
feat(#34): add service-level idle notification deduplication

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -18,6 +18,7 @@ import {
   isConnected,
   requestNonce,
   setPermissionHandler,
+  checkIdle,
 } from './service-client.js'
 
 // Load configuration from config file and environment
@@ -139,6 +140,12 @@ export const Notify = async ({ $, client, directory, serverUrl }) => {
             idleTimer = null
             // Don't send notification if session was canceled
             if (wasCanceled) {
+              return
+            }
+            
+            // Issue #34: Check with service to deduplicate across sessions
+            const shouldSend = await checkIdle(repoName)
+            if (!shouldSend) {
               return
             }
             

--- a/test/test_plugin.bash
+++ b/test/test_plugin.bash
@@ -874,6 +874,27 @@ test_uses_callback_host_for_session_url() {
   }
 }
 
+# =============================================================================
+# Idle Notification Deduplication Tests (Issue #34)
+# =============================================================================
+
+test_imports_check_idle_from_service_client() {
+  # Issue #34: Plugin should import checkIdle from service-client
+  grep -q "checkIdle" "$PLUGIN_DIR/index.js" || {
+    echo "checkIdle not imported/used in index.js"
+    return 1
+  }
+}
+
+test_calls_check_idle_before_sending_notification() {
+  # Issue #34: Before sending idle notification, should check with service
+  # Look for checkIdle call in the idle notification code path
+  grep -q "checkIdle" "$PLUGIN_DIR/index.js" || {
+    echo "checkIdle call not found in idle notification path"
+    return 1
+  }
+}
+
 echo ""
 echo "Session Tracking and Open Session Action Tests (Issue #27):"
 
@@ -885,6 +906,16 @@ for test_func in \
   test_builds_open_session_url \
   test_uses_mobile_ui_url \
   test_uses_callback_host_for_session_url
+do
+  run_test "${test_func#test_}" "$test_func"
+done
+
+echo ""
+echo "Idle Notification Deduplication Tests (Issue #34):"
+
+for test_func in \
+  test_imports_check_idle_from_service_client \
+  test_calls_check_idle_before_sending_notification
 do
   run_test "${test_func#test_}" "$test_func"
 done


### PR DESCRIPTION
## Summary
- Add `check_idle` message type to service IPC protocol for session coordination
- Service tracks recent idle notifications by repo with 30-second deduplication window
- Plugin calls `checkIdle()` before sending idle notifications, suppressing duplicates
- Use unique request IDs to handle concurrent `checkIdle` calls without race conditions
- Fall back to allowing notifications if service is unavailable or unresponsive
- Add periodic cleanup for expired idle records (5-minute max age)

Closes #34