### PR TITLE
fix(#34): remove named export to prevent plugin double-loading

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -23,7 +23,7 @@ import {
 // Load configuration from config file and environment
 const config = loadConfig()
 
-export const Notify = async ({ $, client, directory, serverUrl }) => {
+const Notify = async ({ $, client, directory, serverUrl }) => {
   if (!config.topic) {
     return {}
   }

--- a/test/test_plugin.bash
+++ b/test/test_plugin.bash
@@ -237,10 +237,17 @@ test_idle_notification_shows_repo_context() {
 # =============================================================================
 
 test_index_exports_notify() {
-  grep -q "export const Notify" "$PLUGIN_DIR/index.js" || {
-    echo "Notify export not found in index.js"
+  # Plugin should only use default export to prevent double-loading by OpenCode
+  # (Issue #34: Having both named and default export caused plugin to load twice)
+  grep -q "export default Notify" "$PLUGIN_DIR/index.js" || {
+    echo "Default Notify export not found in index.js"
     return 1
   }
+  # Ensure named export is NOT present (would cause double-loading)
+  if grep -q "export const Notify" "$PLUGIN_DIR/index.js"; then
+    echo "Named export 'export const Notify' found - should only use default export"
+    return 1
+  fi
 }
 
 test_index_has_default_export() {


### PR DESCRIPTION
## Summary
- Remove named export (`export const Notify`), keeping only default export
- Plugin was being loaded twice by OpenCode due to having both export types
- This caused duplicate idle notifications (sessions registering in pairs in service logs)

## Root Cause Analysis
Service logs showed sessions connecting in pairs:
```
[opencode-ntfy] Session registered: a5afc5e1-...
[opencode-ntfy] Session registered: 92596f9a-...
[opencode-ntfy] Session disconnected: a5afc5e1-...
[opencode-ntfy] Session disconnected: 92596f9a-...
```

Each OpenCode session was creating two plugin instances, each with its own idle timer.

Closes #34