### PR TITLE
fix(#41): add reconnection mechanism for permission notifications

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -18,6 +18,7 @@ import {
   isConnected,
   requestNonce,
   setPermissionHandler,
+  tryReconnect,
 } from './service-client.js'
 
 // Load configuration from config file and environment
@@ -236,9 +237,17 @@ const Notify = async ({ $, client, directory, serverUrl }) => {
           return
         }
         
-        // Only send interactive notifications if service is connected
-        if (!config.callbackHost || !isConnected()) {
+        // Only send interactive notifications if callbackHost is configured
+        if (!config.callbackHost) {
           return
+        }
+        
+        // Try to reconnect if not connected (Issue #41: reconnect on permission request)
+        if (!isConnected()) {
+          const reconnected = await tryReconnect()
+          if (!reconnected) {
+            return
+          }
         }
         
         const permissionId = permission.id

--- a/service/server.js
+++ b/service/server.js
@@ -21,23 +21,36 @@ const DEFAULT_SOCKET_PATH = '/tmp/opencode-ntfy.sock'
 const CONFIG_PATH = join(homedir(), '.config', 'opencode-ntfy', 'config.json')
 
 /**
- * Load callback config from config file
+ * Load callback config from environment variables and config file
+ * Environment variables take precedence over config file values
  * @returns {Object} Config with callbackHttps and callbackHost
  */
 function loadCallbackConfig() {
+  // Start with defaults
+  let callbackHttps = false
+  let callbackHost = null
+  
+  // Load from config file
   try {
     if (existsSync(CONFIG_PATH)) {
       const content = readFileSync(CONFIG_PATH, 'utf8')
       const config = JSON.parse(content)
-      return {
-        callbackHttps: config.callbackHttps === true,
-        callbackHost: config.callbackHost || null,
-      }
+      callbackHttps = config.callbackHttps === true
+      callbackHost = config.callbackHost || null
     }
   } catch {
     // Ignore errors
   }
-  return { callbackHttps: false, callbackHost: null }
+  
+  // Environment variables override config file
+  if (process.env.NTFY_CALLBACK_HTTPS !== undefined) {
+    callbackHttps = process.env.NTFY_CALLBACK_HTTPS === 'true' || process.env.NTFY_CALLBACK_HTTPS === '1'
+  }
+  if (process.env.NTFY_CALLBACK_HOST !== undefined && process.env.NTFY_CALLBACK_HOST !== '') {
+    callbackHost = process.env.NTFY_CALLBACK_HOST
+  }
+  
+  return { callbackHttps, callbackHost }
 }
 
 // Nonce storage: nonce -> { sessionId, permissionId, createdAt }
@@ -1547,6 +1560,13 @@ export async function stopService(service) {
   if (service.cleanupInterval) {
     clearInterval(service.cleanupInterval)
   }
+  
+  // Close all active session connections first
+  // This is necessary because server.close() waits for all connections to close
+  for (const [sessionId, socket] of sessions) {
+    socket.destroy()
+  }
+  sessions.clear()
   
   if (service.httpServer) {
     await new Promise((resolve) => {

--- a/test/test_plugin.bash
+++ b/test/test_plugin.bash
@@ -324,6 +324,22 @@ test_index_handles_permission_updated() {
   }
 }
 
+test_index_imports_try_reconnect() {
+  grep -q "tryReconnect" "$PLUGIN_DIR/index.js" || {
+    echo "tryReconnect import not found in index.js"
+    return 1
+  }
+}
+
+test_index_tries_reconnect_on_permission() {
+  # Plugin should try to reconnect when handling permission events if not connected
+  # This is critical for Issue #41 - permission notifications not received
+  grep -A 20 "permission.updated" "$PLUGIN_DIR/index.js" | grep -q "tryReconnect" || {
+    echo "tryReconnect call not found in permission.updated handler"
+    return 1
+  }
+}
+
 # =============================================================================
 # Retry Event Handling Tests (Issue #7)
 # =============================================================================
@@ -754,7 +770,9 @@ echo "Service Integration Tests:"
 for test_func in \
   test_index_imports_service_client \
   test_index_connects_to_service \
-  test_index_handles_permission_updated
+  test_index_handles_permission_updated \
+  test_index_imports_try_reconnect \
+  test_index_tries_reconnect_on_permission
 do
   run_test "${test_func#test_}" "$test_func"
 done

--- a/test/test_service.bash
+++ b/test/test_service.bash
@@ -11,6 +11,9 @@ source "$SCRIPT_DIR/test_helper.bash"
 
 SERVICE_DIR="$(dirname "$SCRIPT_DIR")/service"
 
+# Disable HTTPS redirect for tests (overrides any user config)
+export NTFY_CALLBACK_HTTPS=false
+
 echo "Testing service/server.js module..."
 echo ""
 


### PR DESCRIPTION
## Summary

- Add `tryReconnect()` function to service-client.js for lazy reconnection when permission requests arrive
- Fix race condition where old socket close events could clear new socket reference
- Plugin now tries to reconnect when handling permission.updated events if not connected
- Service properly closes active sessions on stopService() for clean shutdown
- Service config now respects `NTFY_CALLBACK_HTTPS` environment variable for test isolation

Fixes #41