### PR TITLE
fix: improve config command to show prompt per source and interpolate repos

### DIFF
--- a/bin/opencode-pilot
+++ b/bin/opencode-pilot
@@ -339,9 +339,8 @@ async function configCommand() {
         console.log(`      repo: ${source.repo}`);
       } else if (source.working_dir) {
         console.log(`      working_dir: ${source.working_dir}`);
-      } else {
-        console.log(`      working_dir: default`);
       }
+      // Don't show working_dir if it's just the default
     }
   }
 


### PR DESCRIPTION
- Show prompt template used for each source instead of in defaults
- Interpolate repo templates (e.g., `{repository_full_name}`) with configured repos
- Show `(from config)` suffix when repos come from config section
- Change `(uses defaults.working_dir)` to `working_dir: ~ (default)` for consistency