### PR TITLE
feat: use semantic session names based on item titles

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -42,6 +42,8 @@ sources:
   #     completed: false
   #   item:
   #     id: "reminder:{id}"
+  #   session:
+  #     name: "{title}"  # Optional: custom session name (presets have semantic defaults)
 
 # Tool config for custom MCP servers (GitHub/Linear have built-in config)
 # tools:

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,6 +212,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2033,6 +2034,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3128,6 +3130,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5416,6 +5419,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6222,6 +6226,7 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -6276,6 +6281,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -7192,6 +7198,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7619,6 +7626,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/service/actions.js
+++ b/service/actions.js
@@ -242,7 +242,7 @@ export function getCommandInfoNew(item, config, templatesDir, serverUrl) {
   // Build session name
   const sessionName = config.session?.name
     ? buildSessionName(config.session.name, item)
-    : `session-${item.number || item.id || Date.now()}`;
+    : (item.title || `session-${Date.now()}`);
 
   // Build command args
   const args = ["opencode", "run"];
@@ -297,13 +297,14 @@ function buildPrompt(item, config) {
 /**
  * Build command args for action
  * Uses "opencode run" for non-interactive execution
+ * @deprecated Legacy function - not currently used. See getCommandInfoNew instead.
  * @returns {object} { args: string[], cwd: string }
  */
 function buildCommandArgs(item, config) {
   const repoPath = expandPath(config.repo_path || ".");
   const sessionTitle = config.session?.name_template
     ? buildSessionName(config.session.name_template, item)
-    : `issue-${item.number || Date.now()}`;
+    : (item.title || `session-${Date.now()}`);
 
   // Build opencode run command args array (non-interactive)
   // Note: --title sets session title (--session is for continuing existing sessions)

--- a/service/presets/github.yaml
+++ b/service/presets/github.yaml
@@ -22,6 +22,8 @@ my-issues:
   item:
     id: "{html_url}"
   repo: "{repository_full_name}"
+  session:
+    name: "{title}"
 
 review-requests:
   name: review-requests
@@ -33,6 +35,8 @@ review-requests:
   item:
     id: "{html_url}"
   repo: "{repository_full_name}"
+  session:
+    name: "Review: {title}"
 
 my-prs-feedback:
   name: my-prs-feedback
@@ -46,6 +50,8 @@ my-prs-feedback:
   item:
     id: "{html_url}"
   repo: "{repository_full_name}"
+  session:
+    name: "Feedback: {title}"
   # Reprocess when PR is updated (new commits pushed, new comments, etc.)
   # This ensures we re-trigger after addressing review feedback
   reprocess_on:

--- a/service/presets/linear.yaml
+++ b/service/presets/linear.yaml
@@ -21,3 +21,5 @@ my-issues:
     # teamId and assigneeId are required - user must provide
   item:
     id: "linear:{id}"
+  session:
+    name: "{title}"

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -260,6 +260,38 @@ describe('actions.js', () => {
       
       assert.ok(!cmdInfo.args.includes('--attach'), 'Should not include --attach flag');
     });
+
+    test('uses item title as session name when no session.name configured', async () => {
+      const { getCommandInfoNew } = await import('../../service/actions.js');
+      
+      const item = { id: 'reminder-123', title: 'Review quarterly reports' };
+      const config = {
+        path: '~/code/backend',
+        prompt: 'default'
+      };
+      
+      const cmdInfo = getCommandInfoNew(item, config, templatesDir);
+      
+      const titleIndex = cmdInfo.args.indexOf('--title');
+      assert.ok(titleIndex !== -1, 'Should have --title flag');
+      assert.strictEqual(cmdInfo.args[titleIndex + 1], 'Review quarterly reports', 'Should use item title as session name');
+    });
+
+    test('falls back to timestamp when no session.name and no title', async () => {
+      const { getCommandInfoNew } = await import('../../service/actions.js');
+      
+      const item = { id: 'item-123' };
+      const config = {
+        path: '~/code/backend',
+        prompt: 'default'
+      };
+      
+      const cmdInfo = getCommandInfoNew(item, config, templatesDir);
+      
+      const titleIndex = cmdInfo.args.indexOf('--title');
+      assert.ok(titleIndex !== -1, 'Should have --title flag');
+      assert.ok(cmdInfo.args[titleIndex + 1].startsWith('session-'), 'Should fall back to session-{timestamp}');
+    });
   });
 
   describe('discoverOpencodeServer', () => {


### PR DESCRIPTION
## Summary
- Default session name to item.title instead of session-{id}
- Add session.name templates to presets with semantic prefixes (Review:, Feedback:)
- Mark legacy buildCommandArgs as deprecated
- Document session.name option in example config