### PR TITLE
feat: use --dir flag when attaching to remote server

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,18 +94,6 @@ opencode-pilot test-mapping MCP   # Test field mappings
 
 ## Known Issues
 
-### Sessions attached to global server run in wrong directory
-
-When using `server_port` to attach sessions to a global OpenCode server (e.g., OpenCode Desktop with worktree="/"), sessions are created in the server's working directory (typically home) instead of the project directory. This means:
-
-- File tools resolve paths relative to home, not the project
-- The agent sees the wrong `Working directory` in system prompt
-- Git operations may target the wrong repository
-
-**Workaround**: Don't set `server_port` in your config. Sessions will run in the correct directory but won't appear in OpenCode Desktop.
-
-**Upstream issue**: [anomalyco/opencode#7376](https://github.com/anomalyco/opencode/issues/7376)
-
 ### Working directory doesn't switch when templates create worktrees/devcontainers
 
 When a template instructs the agent to create a git worktree or switch to a devcontainer, OpenCode's internal working directory context (`Instance.directory`) doesn't update. This means:

--- a/service/actions.js
+++ b/service/actions.js
@@ -309,9 +309,10 @@ export function getCommandInfoNew(item, config, templatesDir, serverUrl) {
   // Build command args
   const args = ["opencode", "run"];
   
-  // Add --attach if server URL is provided
+  // Add --attach and --dir if server URL is provided
   if (serverUrl) {
     args.push("--attach", serverUrl);
+    args.push("--dir", cwd);
   }
   
   // Add session title

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -232,7 +232,7 @@ describe('actions.js', () => {
       assert.ok(lastArg.includes('Fix bug'), 'Prompt should include title');
     });
 
-    test('includes --attach when serverUrl is provided', async () => {
+    test('includes --attach and --dir when serverUrl is provided', async () => {
       const { getCommandInfoNew } = await import('../../service/actions.js');
       
       const item = { number: 123, title: 'Fix bug' };
@@ -245,6 +245,8 @@ describe('actions.js', () => {
       
       assert.ok(cmdInfo.args.includes('--attach'), 'Should include --attach flag');
       assert.ok(cmdInfo.args.includes('http://localhost:4096'), 'Should include server URL');
+      assert.ok(cmdInfo.args.includes('--dir'), 'Should include --dir flag');
+      assert.ok(cmdInfo.args.includes(cmdInfo.cwd), 'Should include working directory');
     });
 
     test('does not include --attach when serverUrl is null', async () => {


### PR DESCRIPTION
## Summary

- Pass `--dir` flag when using `--attach` to specify working directory
- Update test to verify `--dir` is included with `--attach`

## Dependency

Requires anomalyco/opencode#7378 to be merged first (adds `--dir` flag to `opencode run`).

## Fix

This resolves the "Known Issue" documented in README about sessions attached to global server running in wrong directory. Once the upstream PR is merged, this fix enables:

```bash
# Sessions now run in correct directory AND appear in Desktop UI
opencode run --attach http://localhost:4096 --dir /path/to/project "fix bug"
```