### PR TITLE
fix(presets): add default prompts to review presets

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -26,10 +26,8 @@ sources:
     prompt: worktree
 
   - preset: github/review-requests
-    prompt: review
 
   - preset: github/my-prs-feedback
-    prompt: review-feedback
     repos:
       - myorg/backend
       - myorg/frontend

--- a/service/presets/github.yaml
+++ b/service/presets/github.yaml
@@ -33,6 +33,7 @@ review-requests:
   item:
     id: "{url}"
   repo: "{repository.nameWithOwner}"
+  prompt: review
   session:
     name: "Review: {title}"
 
@@ -44,6 +45,7 @@ my-prs-feedback:
   item:
     id: "{url}"
   repo: "{repository.nameWithOwner}"
+  prompt: review-feedback
   session:
     name: "Feedback: {title}"
   # Reprocess when PR is updated (new commits pushed, new comments, etc.)


### PR DESCRIPTION
## Summary
- Add `prompt: review` to `github/review-requests` preset
- Add `prompt: review-feedback` to `github/my-prs-feedback` preset
- Remove redundant prompt overrides from example config

Previously these presets didn't specify their prompts, so users had to manually add `prompt: review` to get the correct template.