### PR TITLE
Fix lsof path resolution and support server_port fallback

### DIFF
--- a/service/actions.js
+++ b/service/actions.js
@@ -187,9 +187,23 @@ async function sendCommand(serverUrl, sessionId, directory, parsedCommand, optio
  */
 async function getOpencodePorts() {
   try {
-    // Use full path to lsof since /usr/sbin may not be in PATH in all contexts
+    const lsofPaths = [
+      '/usr/sbin/lsof',
+      '/usr/bin/lsof',
+      '/bin/lsof',
+      '/sbin/lsof'
+    ];
+    let lsofBin = 'lsof';
+    for (const p of lsofPaths) {
+      if (existsSync(p)) {
+        lsofBin = p;
+        break;
+      }
+    }
+
+    // Use full path to lsof since standard paths may not be in PATH in all contexts
     // (e.g., when running as a service or from certain shell environments)
-    const output = execSync('/usr/sbin/lsof -i -P 2>/dev/null | grep -E "opencode.*LISTEN" || true', {
+    const output = execSync(`${lsofBin} -i -P 2>/dev/null | grep -E "opencode.*LISTEN" || true`, {
       encoding: 'utf-8',
       timeout: 30000
     });
@@ -290,7 +304,15 @@ export async function discoverOpencodeServer(targetDir, options = {}) {
   const fetchFn = options.fetch || fetch;
   const preferredPort = options.preferredPort ?? getServerPort();
   
-  const ports = await getPorts();
+  let ports = await getPorts();
+
+  // If a preferredPort is configured but not already detected via lsof
+  // (e.g. because lsof couldn't find/see it, or lsof isn't available),
+  // append it to the ports list so that we still attempt to discover it.
+  if (preferredPort && !ports.includes(preferredPort)) {
+    ports = [...ports, preferredPort];
+  }
+
   if (ports.length === 0) {
     debug('discoverOpencodeServer: no servers found');
     return null;

--- a/service/actions.js
+++ b/service/actions.js
@@ -20,7 +20,7 @@
  */
 
 import { execSync } from "child_process";
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, accessSync, constants } from "fs";
 import { debug } from "./logger.js";
 import { getNestedValue } from "./utils.js";
 import { getServerPort } from "./repo-config.js";
@@ -196,8 +196,13 @@ async function getOpencodePorts() {
     let lsofBin = 'lsof';
     for (const p of lsofPaths) {
       if (existsSync(p)) {
-        lsofBin = p;
-        break;
+        try {
+          accessSync(p, constants.X_OK);
+          lsofBin = p;
+          break;
+        } catch {
+          // Path exists but is not executable, continue to next candidate
+        }
       }
     }
 

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -653,6 +653,29 @@ Check for bugs and security issues.`;
       
       assert.strictEqual(result, null, 'Should return null when server returns unhealthy project data');
     });
+
+    test('checks configured preferredPort even when getPorts returns no ports', async () => {
+      const { discoverOpencodeServer } = await import('../../service/actions.js');
+
+      const mockPorts = async () => [];
+      const mockFetch = async (url) => {
+        if (url === 'http://localhost:4096/project/current') {
+          return {
+            ok: true,
+            json: async () => ({ id: 'preferred-proj', worktree: '/Users/test/project', sandboxes: [], time: { created: 1 } })
+          };
+        }
+        return { ok: false };
+      };
+
+      const result = await discoverOpencodeServer('/Users/test/project', {
+        getPorts: mockPorts,
+        fetch: mockFetch,
+        preferredPort: 4096
+      });
+
+      assert.strictEqual(result, 'http://localhost:4096');
+    });
   });
 
   describe('executeAction', () => {


### PR DESCRIPTION
Dynamically resolves the lsof path on linux and supports fallback to preferredPort when lsof checks cannot find the running opencode server.

Fixes #117

---
*PR created automatically by Jules for task [3601355634390134876](https://jules.google.com/task/3601355634390134876) started by @athal7*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server discovery when port information is unavailable.
  * Added support for detecting running servers across common system configurations.
  * Configured preferred ports are now checked reliably during server discovery.

* **Tests**
  * Added coverage for discovering a server through its configured preferred port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->