### PR TITLE
fix(ci): don't prefix release tags with the package name

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "package-name": "opencode-pilot"
+      "package-name": "opencode-pilot",
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
release-please defaults to component-prefixed tags (e.g. opencode-pilot-v1.0.0), which don't match this repo's existing plain v-tag history. Disable that so it finds the real latest release instead of recomputing from full history.